### PR TITLE
Update WritingYourOwnModules.md

### DIFF
--- a/DMBS/WritingYourOwnModules.md
+++ b/DMBS/WritingYourOwnModules.md
@@ -63,6 +63,7 @@ user:
     $(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
 
 As well as complaining if they are set, but currently empty:
+
     $(call ERROR_IF_EMPTY, SOME_MANDATORY_VARIABLE)
     $(call ERROR_IF_EMPTY, SOME_OPTIONAL_BUT_NON_EMPTY_VARIABLE)
 


### PR DESCRIPTION
Corrects the displayed markdown

Also the text suggests to include the dmbs core etc. The only reference I have is lufa, and LUFA just ignores that if I am right: https://github.com/abcminiuser/lufa/tree/master/LUFA/Build/LUFA

Do you have any other examples for dmbs modules? A Module template would be nice for a library with a .h and .c file.

I will use this PR to ask a few questions:
- The "module hooks" add some information what the module defines (targets, input/output vars etc). To me it seems that this is not important at all, because I can leave out the information and targets will still work and variables will give errors even when they are listed as mandatory. So the sanity check still is part of the module. To me the hooks header seems useless or has some bugs?
