### PR TITLE
Some C++ fixes

### DIFF
--- a/DMBS/gcc.mk
+++ b/DMBS/gcc.mk
@@ -131,7 +131,7 @@ endif
 
 # Additional language specific compiler flags
 BASE_C_FLAGS   := -x c -O$(OPTIMIZATION) -std=$(C_STANDARD) -Wstrict-prototypes
-BASE_CPP_FLAGS := -x c++ -O$(OPTIMIZATION) -std=$(CPP_STANDARD)
+BASE_CPP_FLAGS := -x c++ -O$(OPTIMIZATION) -std=$(CPP_STANDARD) -fno-exceptions -fno-threadsafe-statics
 BASE_ASM_FLAGS := -x assembler-with-cpp
 
 # Create a list of flags to pass to the linker

--- a/DMBS/gcc.mk
+++ b/DMBS/gcc.mk
@@ -108,7 +108,8 @@ DEPENDENCY_FILES := $(OBJECT_FILES:%.o=%.d)
 # Create a list of common flags to pass to the compiler/linker/assembler
 BASE_CC_FLAGS    := -pipe -g$(DEBUG_FORMAT) -g$(DEBUG_LEVEL)
 ifneq ($(findstring $(ARCH), AVR8 XMEGA),)
-   BASE_CC_FLAGS += -mmcu=$(MCU) -fshort-enums -fno-inline-small-functions -fpack-struct
+   BASE_C_FLAGS += -fpack-struct
+   BASE_CC_FLAGS += -mmcu=$(MCU) -fshort-enums -fno-inline-small-functions
 else ifneq ($(findstring $(ARCH), UC3),)
    BASE_CC_FLAGS += -mpart=$(MCU:at32%=%) -masm-addr-pseudos
 endif


### PR DESCRIPTION
This adds ```-fno-exceptions``` for C++ files and makes ```-fpack-struct``` only applicable to C files.