### PR TITLE
Added DMBS_ARCH_ define

### DIFF
--- a/DMBS/gcc.mk
+++ b/DMBS/gcc.mk
@@ -117,7 +117,7 @@ else ifneq ($(findstring $(ARCH), UC3),)
 endif
 BASE_CC_FLAGS += -Wall -fno-strict-aliasing -funsigned-char -funsigned-bitfields -ffunction-sections
 BASE_CC_FLAGS += -I.
-BASE_CC_FLAGS += -DARCH=ARCH_$(ARCH)
+BASE_CC_FLAGS += -DARCH=ARCH_$(ARCH) -DDMBS_ARCH_$(ARCH)
 ifneq ($(F_CPU),)
    BASE_CC_FLAGS += -DF_CPU=$(F_CPU)UL
 endif


### PR DESCRIPTION
This define is required to check for [example](https://github.com/NicoHood/IRLremote/pull/20):

```c
#if defined(ARDUINO_ARCH_AVR) || defined(DMBS_ARCH_AVR8)
    #include <util/atomic.h>
#elif defined(ARDUINO_ARCH_ESP8266) || defined(ESP8266)
[...]
#endif
```

I cannot use `ARCH` directly as `ARCH == ARCH_AVR8` only works if `ARCH_AVR8` has an initial value of 1, 2, 3 etc. LUFA defines those values, but I dont want to redefine them everywhere. Thatswhy a new macro was introduced.

In the long term I suggest moving LUFA also to the new makro, as its more clear and does not need the overhead. But for now both can exist.