### PR TITLE
Fix high memory usage

### DIFF
--- a/DMBS/gcc.mk
+++ b/DMBS/gcc.mk
@@ -115,7 +115,7 @@ ifneq ($(findstring $(ARCH), AVR8 XMEGA),)
 else ifneq ($(findstring $(ARCH), UC3),)
    BASE_CC_FLAGS += -mpart=$(MCU:at32%=%) -masm-addr-pseudos
 endif
-BASE_CC_FLAGS += -Wall -fno-strict-aliasing -funsigned-char -funsigned-bitfields -ffunction-sections
+BASE_CC_FLAGS += -Wall -fno-strict-aliasing -funsigned-char -funsigned-bitfields -ffunction-sections -fdata-sections
 BASE_CC_FLAGS += -I.
 BASE_CC_FLAGS += -DARCH=ARCH_$(ARCH) -DDMBS_ARCH_$(ARCH)
 ifneq ($(F_CPU),)


### PR DESCRIPTION
After spending quite some time debugging this kind of failure (details https://github.com/olikraus/u8g2/issues/618):
```
/usr/lib/gcc/avr/4.9.2/../../../avr/bin/ld: address 0x819b17 of Keyboard.elf section `.bss' is not within region `data'
```
I tracked down the issue to --gc-sections not purging data sections, because it won't work unless this flag is used. The situation seems to be the same as described here: https://gcc.gnu.org/onlinedocs/gnat_ugn/Compilation-options.html.

In my particular case, there were loads of functions with static variables inside. I was not using them at all, but the linker could not gc them. I was able to reproduce the issue, see the RAM usage increase (with make size), and eventually, grow to the failure above.

So, without -fdata-sections, we end up using more RAM, for nothing. I honestly see no bad outcome of this being the default setting, as it will save users of high RAM usage.

I'm posting this here, but I actually got the issue at https://github.com/abcminiuser/lufa, so I suppose, lufa should get this change pushed as well.