### PR TITLE
Add optional variable `AVRDUDE_MCU` to avrdude.mk

### DIFF
--- a/DMBS/avrdude.md
+++ b/DMBS/avrdude.md
@@ -96,6 +96,10 @@ be assumed.
 <table>
  <tbody>
    <tr>
+    <td>AVRDUDE_MCU</td>
+    <td>Override the `MCU` variable for `avrdude`. On some controllers, `avrdude` expects another spelling than the compiler needs. Default is `MCU`.</td>
+   </tr>
+   <tr>
     <td>AVRDUDE_PROGRAMMER</td>
     <td>Name of the programmer/debugger tool or bootloader to communicate with (e.g. `jtagicemkii`). Default is `jtagicemkii`.</td>
    </tr>

--- a/DMBS/avrdude.mk
+++ b/DMBS/avrdude.mk
@@ -10,7 +10,7 @@ DMBS_BUILD_MODULES         += AVRDUDE
 DMBS_BUILD_TARGETS         += avrdude-lfuse avrdude-hfuse avrdude-efuse avrdude-lock avrdude-fuses
 DMBS_BUILD_TARGETS         += avrdude avrdude-ee avrdude-all avrdude-all-ee
 DMBS_BUILD_MANDATORY_VARS  += MCU TARGET
-DMBS_BUILD_OPTIONAL_VARS   += AVRDUDE_PROGRAMMER AVRDUDE_PORT AVRDUDE_FLAGS AVRDUDE_MEMORY AVRDUDE_BAUD
+DMBS_BUILD_OPTIONAL_VARS   += AVRDUDE_MCU AVRDUDE_PROGRAMMER AVRDUDE_PORT AVRDUDE_FLAGS AVRDUDE_MEMORY AVRDUDE_BAUD
 DMBS_BUILD_OPTIONAL_VARS   += AVRDUDE_LFUSE AVRDUDE_HFUSE AVRDUDE_EUSE AVRDUDE_LOCK
 DMBS_BUILD_PROVIDED_VARS   +=
 DMBS_BUILD_PROVIDED_MACROS +=
@@ -20,6 +20,7 @@ DMBS_MODULE_PATH := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 include $(DMBS_MODULE_PATH)/core.mk
 
 # Default values of optionally user-supplied variables
+AVRDUDE_MCU        ?= $(MCU)
 AVRDUDE_PROGRAMMER ?= jtagicemkii
 AVRDUDE_PORT       ?= usb
 AVRDUDE_FLAGS      ?=
@@ -32,7 +33,7 @@ AVRDUDE_BAUD       ?=
 
 # Sanity check user supplied values
 $(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
-$(call ERROR_IF_EMPTY, MCU)
+$(call ERROR_IF_EMPTY, AVRDUDE_MCU)
 $(call ERROR_IF_EMPTY, TARGET)
 $(call ERROR_IF_EMPTY, AVRDUDE_PROGRAMMER)
 $(call ERROR_IF_EMPTY, AVRDUDE_PORT)
@@ -41,39 +42,39 @@ $(call ERROR_IF_EMPTY, AVRDUDE_PORT)
 MSG_AVRDUDE_CMD    := ' [AVRDUDE] :'
 
 # Construct base avrdude command flags
-BASE_AVRDUDE_FLAGS := -p $(MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
+BASE_AVRDUDE_FLAGS := -p $(AVRDUDE_MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
 ifneq ($(AVRDUDE_BAUD),)
   BASE_AVRDUDE_FLAGS += -b $(AVRDUDE_BAUD)
 endif
 
 # Programs in the target FLASH memory using AVRDUDE
 avrdude: $(TARGET).hex $(MAKEFILE_LIST)
-	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(MCU)\" FLASH using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
+	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(AVRDUDE_MCU)\" FLASH using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
 	avrdude $(BASE_AVRDUDE_FLAGS) -U $(AVRDUDE_MEMORY):w:$< $(AVRDUDE_FLAGS)
 
 # Programs in the target EEPROM memory using AVRDUDE
 avrdude-ee: $(TARGET).eep $(MAKEFILE_LIST)
-	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(MCU)\" EEPROM using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
+	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(AVRDUDE_MCU)\" EEPROM using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
 	avrdude $(BASE_AVRDUDE_FLAGS) -U eeprom:w:$< $(AVRDUDE_FLAGS)
 
 # Programs in the target fuses using AVRDUDE
 avrdude-lfuse: $(MAKEFILE_LIST)
-	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(MCU)\" low fuse using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
+	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(AVRDUDE_MCU)\" low fuse using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
 	$(call ERROR_IF_EMPTY, AVRDUDE_LFUSE)
 	avrdude $(BASE_AVRDUDE_FLAGS) -Ulfuse:w:$(AVRDUDE_LFUSE):m $(AVRDUDE_FLAGS)
 
 avrdude-hfuse: $(MAKEFILE_LIST)
-	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(MCU)\" high fuse using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
+	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(AVRDUDE_MCU)\" high fuse using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
 	$(call ERROR_IF_EMPTY, AVRDUDE_HFUSE)
 	avrdude $(BASE_AVRDUDE_FLAGS) -Uhfuse:w:$(AVRDUDE_HFUSE):m $(AVRDUDE_FLAGS)
 
 avrdude-efuse: $(MAKEFILE_LIST)
-	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(MCU)\" extended fuse using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
+	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(AVRDUDE_MCU)\" extended fuse using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
 	$(call ERROR_IF_EMPTY, AVRDUDE_EFUSE)
 	avrdude $(BASE_AVRDUDE_FLAGS) -Uefuse:w:$(AVRDUDE_EFUSE):m $(AVRDUDE_FLAGS)
 
 avrdude-lock: $(MAKEFILE_LIST)
-	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(MCU)\" lock bits using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
+	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(AVRDUDE_MCU)\" lock bits using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
 	$(call ERROR_IF_EMPTY, AVRDUDE_LOCK)
 	avrdude $(BASE_AVRDUDE_FLAGS) -Ulock:w:$(AVRDUDE_LOCK):m $(AVRDUDE_FLAGS)
 


### PR DESCRIPTION
For some controllers, avrdude needs another spelling than the compiler
needs. For example the ATmega48PA. The compiler is fine with
`atmega48pa` but avrdude needs `m48p`.
This change lets the avrdude target use the new variable `AVRDUDE_MCU`
which is set to `MCU` by default. But the user is able to override it.