### PR TITLE
Made `AVRDUDE_EFUSE` optional for `avrdude-fuses`

### DIFF
--- a/DMBS/avrdude.md
+++ b/DMBS/avrdude.md
@@ -48,7 +48,10 @@ The following targets are supported by this module:
    </tr>
    <tr>
     <td>avrdude-fuses</td>
-    <td>Program the device fuses (lfuse, hfuse, efuse, lock bits).</td>
+    <td>
+     Program the device fuses (lfuse, hfuse, efuse, lock bits).<br>
+     Requires AVRDUDE_LFUSE, AVRDUDE_HFUSE and AVRDUDE_LOCK variable set. AVRDUDE_EFUSE is optional.
+    </td>
    </tr>
    <tr>
     <td>avrdude</td>
@@ -175,6 +178,9 @@ this module.
 
 The changes to this module since its initial release are listed below, as of the
 DMBS version where the change was made.
+
+### 20200412
+Made `AVRDUDE_EFUSE` optional for `avrdude-fuses` because not every AVR has this fuse.
 
 ### 20171231
 Added `AVRDUDE_BAUD`, `AVRDUDE_HFUSE`, `AVRDUDE_EFUSE`, `AVRDUDE_LFUSE` and

--- a/DMBS/avrdude.mk
+++ b/DMBS/avrdude.mk
@@ -11,7 +11,7 @@ DMBS_BUILD_TARGETS         += avrdude-lfuse avrdude-hfuse avrdude-efuse avrdude-
 DMBS_BUILD_TARGETS         += avrdude avrdude-ee avrdude-all avrdude-all-ee
 DMBS_BUILD_MANDATORY_VARS  += MCU TARGET
 DMBS_BUILD_OPTIONAL_VARS   += AVRDUDE_MCU AVRDUDE_PROGRAMMER AVRDUDE_PORT AVRDUDE_FLAGS AVRDUDE_MEMORY AVRDUDE_BAUD
-DMBS_BUILD_OPTIONAL_VARS   += AVRDUDE_LFUSE AVRDUDE_HFUSE AVRDUDE_EUSE AVRDUDE_LOCK AVRDUDE_BITCLK
+DMBS_BUILD_OPTIONAL_VARS   += AVRDUDE_LFUSE AVRDUDE_HFUSE AVRDUDE_EFUSE AVRDUDE_LOCK AVRDUDE_BITCLK
 DMBS_BUILD_PROVIDED_VARS   +=
 DMBS_BUILD_PROVIDED_MACROS +=
 
@@ -31,6 +31,13 @@ AVRDUDE_EFUSE      ?=
 AVRDUDE_LOCK       ?=
 AVRDUDE_BAUD       ?=
 AVRDUDE_BITCLK     ?=
+
+# Set avrdude-efuse-target as dependency for avrdude-fuses only if defined, because not every AVR has this fuse
+ifneq ($(AVRDUDE_EFUSE),)
+  AVRDUDE_EFUSE_TARGET := avrdude-efuse
+else
+  AVRDUDE_EFUSE_TARGET :=
+endif
 
 # Sanity check user supplied values
 $(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
@@ -82,7 +89,7 @@ avrdude-lock: $(MAKEFILE_LIST)
 	$(call ERROR_IF_EMPTY, AVRDUDE_LOCK)
 	avrdude $(BASE_AVRDUDE_FLAGS) -Ulock:w:$(AVRDUDE_LOCK):m $(AVRDUDE_FLAGS)
 
-avrdude-fuses: avrdude-lfuse avrdude-hfuse avrdude-efuse avrdude-lock
+avrdude-fuses: avrdude-lfuse avrdude-hfuse $(AVRDUDE_EFUSE_TARGET) avrdude-lock
 
 avrdude-all: avrdude avrdude-fuses
 


### PR DESCRIPTION
I made `AVRDUDE_EFUSE` optional for `avrdude-fuses` because not every AVR has this fuse.
For example the ATmega32A doesn't have it.
And I fixed a typo in `DMBS_BUILD_OPTIONAL_VARS`.

Now you can use `avrdude-fuses` to set your fuses for this chip, too.